### PR TITLE
change workflow timeout from 40 to 60 minutes

### DIFF
--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     steps:
       - uses: szenius/set-timezone@v1.2


### PR DESCRIPTION
the title says it, and hopefully it's enough for running mutation tests.